### PR TITLE
Updating to default SIG licence (CC-by-40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<img src="https://github.com/finos/branding/blob/master/sig-logos/ai-readiness/Horizontal/2024_AIReadiness_Logo_Horizontal.svg" width="450">
+<img src="https://github.com/finos/branding/blob/master/sig-logos/ai-readiness/Horizontal/2024_AIReadiness_Logo_Horizontal.svg" width="450"> 
+
+[![CC BY 4.0][cc-by-shield]][cc-by]
 
 # AI Readiness
 
@@ -41,6 +43,12 @@ The group is led by the three co-chairs:
 
 Copyright © 2024 Fintech Open Source Foundation
 
-Distributed under the [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/deed.en).
+This work is licensed under a [Creative Commons Attribution 4.0 International License][cc-by].
 
-SPDX-License-Identifier: [CC0 1.0 Universal](https://spdx.org/licenses/CC0-1.0.html).
+[![CC BY 4.0][cc-by-image]][cc-by]
+
+[cc-by]: http://creativecommons.org/licenses/by/4.0/
+[cc-by-image]: https://i.creativecommons.org/l/by/4.0/88x31.png
+[cc-by-shield]: https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg
+
+SPDX-License-Identifier: [CC BY 4.0](https://spdx.org/licenses/CC-BY-4.0.html).


### PR DESCRIPTION
Our SIGs used CC-by-40 as a default license - see [official governance](https://community.finos.org/docs/governance/#special-interest-groups:~:text=Documents%20produced%20or%20contributed%20as%20part%20of%20the%20SIG%20will%20be%20contributed%20and%20made%20available%20under%20CC%2DBY%2D4.0.).

So I am proposing to align this group to the standard SIG documentation license 