### PR TITLE
Stepping down as co-chair

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ We use the following channels:
  - Meetings are held bi-weekly, with details found on the [FINOS community calendar](https://www.finos.org/calendar)
 
 The group is led by the three co-chairs:
- - Colin Eberhardt, CTO, Scott Logic (co-chair)
  - Ian Micallef, Citi, ICG Head of Developer Engineering  (co-chair)
  - Madhu Coimbatore, Morgan Stanley, Head of Firmwide AI Development Platform (co-chair)
 


### PR DESCRIPTION
I'm pretty busy across multiple FINOS initiatives (Board member, FINOS OSS Survey, AI Governance), and need to streamline a bit.

With that in mind, I'm stepping down as co-chair of the AI Readiness SIG, in order to concentrate my efforts directly on the [Governance Framework](https://github.com/finos/ai-governance-framework) development, where I intend to continue in an active role as lead maintainer. I'm also happy to chair the fortnightly GF framework calls.